### PR TITLE
feat(OtpInput): hide number input spin buttons with custom styles in copied code snippet

### DIFF
--- a/src/Components/Overview/SidebarContent/Content/Inputs/OtpInput.jsx
+++ b/src/Components/Overview/SidebarContent/Content/Inputs/OtpInput.jsx
@@ -160,6 +160,17 @@ const OtpInput = () => {
     };
 
     return (
+        <>
+        <style>{`
+                input[type="number"]::-webkit-inner-spin-button,
+                input[type="number"]::-webkit-outer-spin-button {
+                    -webkit-appearance: none;
+                    margin: 0;
+                }
+                input[type="number"] {
+                    -moz-appearance: textfield;
+                }
+        `}</style>
         <div className="grid grid-cols-4 gap-[10px] w-full md:w-[50%]">
             {
                 Array.from({length}).map((_, index) => (
@@ -175,6 +186,7 @@ const OtpInput = () => {
                 ))
             }
         </div>
+        </>
     );
 };
 
@@ -272,6 +284,17 @@ const OtpInput = () => {
     }
 
     return (
+        <>
+        <style>{`
+                input[type="number"]::-webkit-inner-spin-button,
+                input[type="number"]::-webkit-outer-spin-button {
+                    -webkit-appearance: none;
+                    margin: 0;
+                }
+                input[type="number"] {
+                    -moz-appearance: textfield;
+                }
+        `}</style>
         <div className="grid grid-cols-4 gap-[10px] w-full md:w-[50%]">
             {
                 Array.from({length}).map((_, index) => (
@@ -289,6 +312,7 @@ const OtpInput = () => {
                 ))
             }
         </div>
+        </>
     );
 };
 


### PR DESCRIPTION
This ensures spin buttons are consistently hidden, both in preview and when the component is reused from the code snippet.

![image](https://github.com/user-attachments/assets/8bb644cb-df8a-4663-bf9c-62e3f4d3b1dd)
