### PR TITLE
Fix: small bug in Testimonial 7 Preview and Code buttons doing reverse roles

### DIFF
--- a/src/Components/Overview/SidebarContent/Content/Feedback/Testimonial.jsx
+++ b/src/Components/Overview/SidebarContent/Content/Feedback/Testimonial.jsx
@@ -620,8 +620,8 @@ export default Testimonial;
                     <ComponentDescription text='This is a testimonial component. Showcase user feedback and reviews
             with a stylish, engaging layout.'/>
 
-                    <ToggleTab code={testimonial7Code} setPreview={setTestimonial7Code} preview={testimonial7Preview}
-                               setCode={setTestimonial7Preview}/>
+                    <ToggleTab code={testimonial7Code} setPreview={setTestimonial7Preview} preview={testimonial7Preview}
+                               setCode={setTestimonial7Code}/>
 
                     <ComponentWrapper>
                         {testimonial7Preview && (


### PR DESCRIPTION
This PR makes a minor fix to the logic for toggling code and preview states in the testimonial component. The change corrects the assignment of props in the `ToggleTab` component to ensure the preview and code toggles work as intended.

I can't use a screenRecord to show the bug properly at the moment, but it can easily be checked at https://zenui.net/components/testimonials, going to the very last one, and will notice that the user have to click Preview again to actually check the code, and vice-versa.

This PR makes sure testimonial 7 actually follow the same pattern as the others testimonials.