### PR TITLE
Added some fixes in Overview page & navbar

### DIFF
--- a/src/Components/Home/Navbar.jsx
+++ b/src/Components/Home/Navbar.jsx
@@ -147,14 +147,14 @@ const Navbar = ({className}) => {
                                 initial={{opacity: 0, scale: 0.8}}
                                 animate={{opacity: 1, scale: 1}}
                                 exit={{opacity: 0, scale: 0.8}}
-                                className="absolute dark:bg-slate-800 dark:border-darkBorderColor top-[64px] left-[-250px] gap-x-[30px] w-[700px] grid grid-cols-2 gap-y-3 bg-white shadow-[0px_40px_80px_-8px_rgba(145,158,171,0.24)] rounded-high p-5 mt-2"
+                                className="absolute dark:bg-slate-800 dark:border-darkBorderColor border top-[64px] left-[-250px] gap-x-[30px] w-[700px] grid grid-cols-2 gap-y-3 bg-white shadow-[0px_40px_80px_-8px_rgba(145,158,171,0.24)] rounded-high p-5"
                                 onMouseEnter={() => setIsToolsHover(true)}
                                 onMouseLeave={() => setIsToolsHover(false)}
                             >
                                 <div className='flex flex-col gap-3'>
 
                                     <Link to='/shortcut-generator'
-                                          className='p-[8px] transition-all duration-200 dark:hover:bg-brandColor/10 hover:bg-brandColor/5 dark:hover:bg-slate-800 rounded-normal flex items-center gap-[10px]'>
+                                          className='p-[8px] transition-all duration-200 dark:hover:bg-slate-700 hover:bg-gray-100 rounded-normal flex items-center gap-[10px]'>
 
                                         <div className='bg-brandColor/5 p-[14px] rounded-normal text-[1.6rem]'>
                                             <FaRegKeyboard/>
@@ -171,7 +171,7 @@ const Navbar = ({className}) => {
                                     </Link>
 
                                     <Link to='/color-palette'
-                                          className='p-[8px] transition-all duration-200 dark:hover:bg-brandColor/10 hover:bg-brandColor/5 dark:hover:bg-slate-800 rounded-normal flex items-center gap-[10px]'>
+                                          className='p-[8px] transition-all duration-200 dark:hover:bg-slate-700 hover:bg-gray-100 rounded-normal flex items-center gap-[10px]'>
 
                                         <div className='bg-brandColor/5 p-3 rounded-normal text-[1.8rem]'>
                                             <LiaPaletteSolid/>
@@ -192,7 +192,7 @@ const Navbar = ({className}) => {
                                 <div className='flex flex-col gap-3'>
 
                                     <Link to='/icons'
-                                          className='p-[8px] transition-all duration-200 dark:hover:bg-brandColor/10 hover:bg-brandColor/5 dark:hover:bg-slate-800 rounded-normal flex items-center gap-[10px]'>
+                                          className='p-[8px] transition-all duration-200 dark:hover:bg-slate-700 hover:bg-gray-100 rounded-normal flex items-center gap-[10px]'>
 
                                         <div className='bg-brandColor/5 p-3.5 rounded-normal text-[1.5rem]'>
                                             <TbIcons/>
@@ -209,7 +209,7 @@ const Navbar = ({className}) => {
                                     </Link>
 
                                     <Link to='/config-generator'
-                                          className='p-[8px] transition-all duration-200 dark:hover:bg-brandColor/10 hover:bg-brandColor/5 dark:hover:bg-slate-800 rounded-normal flex items-center gap-[10px]'>
+                                          className='p-[8px] transition-all duration-200 dark:hover:bg-slate-700 hover:bg-gray-100 rounded-normal flex items-center gap-[10px]'>
 
                                         <div className='bg-brandColor/5 p-[14px] rounded-normal'>
                                             <ConfigAiIcon/>
@@ -233,7 +233,7 @@ const Navbar = ({className}) => {
                                 <div className='flex flex-col'>
 
                                     <Link to='/semantic-tag-master'
-                                          className='p-[8px] transition-all duration-200 dark:hover:bg-brandColor/10 hover:bg-brandColor/5 dark:hover:bg-slate-800 rounded-normal flex items-center gap-[10px]'>
+                                          className='p-[8px] transition-all duration-200 dark:hover:bg-slate-700 hover:bg-gray-100 rounded-normal flex items-center gap-[10px]'>
 
                                         <div className='bg-brandColor/5 p-3.5 rounded-normal text-[1.5rem]'>
                                             <ImHtmlFive2/>

--- a/src/Components/Overview/SidebarContent/Content/Overview.jsx
+++ b/src/Components/Overview/SidebarContent/Content/Overview.jsx
@@ -40,7 +40,7 @@ const Overview = () => {
             <div className="mt-8 w-full text-text">
                 <ContentHeader text={"What will you get?"}/>
                 <ul className="flex flex-col gap-3 list-disc ml-8 mt-3">
-                    <li className="p-0 hover:bg-transparent border-none hover:border-none hover:font-[400] hover:bg-secondary">
+                    <li className="p-0 hover:bg-transparent border-none dark:text-darkSubTextColor hover:border-none hover:font-[400] hover:bg-secondary">
                         <b>Reusable Advanced Components:</b> Access a suite of highly customizable, production-ready
                         components built with best practices in mind. From complex forms to interactive tabs and
                         accordions, these components save development time while ensuring consistency across your


### PR DESCRIPTION
1. Updated hover styles of Tools in Navbar : Changed from bg-brandColor/10 to dark:hover:bg-slate-700 hover:bg-gray-100 for better theme consistency because currently in dark mode hover is not showing.

2. Fixed dropdown disappearing issue:  Removed the mt-2 margin that was creating a gap between the "Tools" text and the dropdown, which was causing the dropdown to close when moving the mouse to it.

3. Updates Overview Section : One of the section is not became light when User in dark mode.
<img width="1341" height="740" alt="Screenshot_1944" src="https://github.com/user-attachments/assets/bded05e5-2ff8-475a-b36a-f6d18729a945" />
