### PR TITLE
feat: add blur background modal,stripped progress bar and fix dark mode issues

### DIFF
--- a/src/Components/Overview/SidebarContent/Content/Navigation/Modals.jsx
+++ b/src/Components/Overview/SidebarContent/Content/Navigation/Modals.jsx
@@ -49,6 +49,10 @@ const Modals = () => {
     const [deleteModalPreview, setDeleteModalPreview] = useState(true);
     const [deleteModalCode, setDeleteModalCode] = useState(false);
 
+    // blur background modal
+    const [blurModalPreview, setBlurModalPreview] = useState(true);
+    const [blurModalCode, setBlurModalCode] = useState(false);
+
     // handling all of modal actions
     const [modal1Open, setModal1Open] = useState(false);
     const [modal2Open, setModal2Open] = useState(false);
@@ -56,6 +60,7 @@ const Modals = () => {
     const [modal4Open, setModal4Open] = useState(false);
     const [modal5Open, setModal5Open] = useState(false);
     const [modal10Open, setModal10Open] = useState(false);
+    const [modal11Open, setModal11Open] = useState(false);
 
     const [disabledButton, setDisabledButton] = useState(true);
 
@@ -1016,6 +1021,151 @@ const Modal = () => {
 
 export default Modal;
           '
+                            />
+                        )}
+                    </ComponentWrapper>
+
+                    <div className='mt-8'>
+                        <ContentHeader id='blur_background_modal' text={'Focused Modal'}/>
+                    </div>
+
+                    <ComponentDescription text='A modal with a blurred background effect that creates a frosted glass
+            appearance, providing focus on the modal while maintaining visual context.'/>
+
+                    <ToggleTab code={blurModalCode} setPreview={setBlurModalPreview} setCode={setBlurModalCode}
+                               preview={blurModalPreview}/>
+
+                    <ComponentWrapper>
+                        {blurModalPreview && (
+                            <div className='p-8 mb-4 flex items-center gap-5 justify-center'>
+                                <div className='w-full flex items-center justify-center'>
+                                    <button
+                                        className='px-4 py-2 bg-primary text-secondary rounded '
+                                        onClick={() => setModal11Open(true)}
+                                    >
+                                        Open Modal
+                                    </button>
+                                </div>
+                                <div
+                                    className={`${
+                                        modal11Open
+                                            ? ' scale-[1] opacity-100'
+                                            : ' scale-[0] opacity-0'
+                                    } w-full h-screen fixed top-0 left-0 z-[200000000] backdrop-blur-md dark:bg-black/50 bg-white/30 flex items-center justify-center transition-all duration-300`}
+                                >
+                                    <div
+                                        className={`w-[90%] 1024px:w-[35%] dark:bg-slate-800 bg-white/90 backdrop-blur-xl border dark:border-slate-700 border-gray-200 rounded-lg p-5 shadow-2xl`}
+                                    >
+                                        <div className='w-full flex justify-between items-start'>
+                                            <div>
+                                                <h2 className='text-[1.7rem] dark:text-[#abc2d3] font-[600] text-[#202020]'>
+                                                    Welcome Back!
+                                                </h2>
+                                                <p className='text-[1rem] dark:text-[#abc2d3]/80 text-[#525252] mt-1'>
+                                                    Continue your journey with us
+                                                </p>
+                                            </div>
+
+                                            <RxCross1
+                                                className='p-2 text-[2.5rem] dark:text-[#abc2d3]/80 dark:hover:bg-slate-900/70 hover:bg-gray-100 rounded-full transition-all duration-300 cursor-pointer'
+                                                onClick={() => setModal11Open(false)}
+                                            />
+                                        </div>
+
+                                        <div className='mt-6'>
+                                            <p className='text-[1rem] dark:text-[#abc2d3]/90 text-gray-700 leading-relaxed'>
+                                                Experience a modern modal with a beautiful blur effect. 
+                                                This creates an elegant overlay while maintaining context 
+                                                of the content behind it.
+                                            </p>
+                                        </div>
+
+                                        <div className='flex items-center gap-2 1024px:gap-3 w-full justify-end mt-8'>
+                                            <button
+                                                className='px-5 py-2.5 dark:hover:bg-slate-900/50 hover:bg-gray-100 border dark:border-slate-700 dark:text-[#abc2d3] border-gray-300 rounded-lg text-[#585858] font-[500] transition-all duration-200'
+                                                onClick={() => setModal11Open(false)}
+                                            >
+                                                Cancel
+                                            </button>
+                                            <button
+                                                className='px-5 py-2.5 bg-primary rounded-lg text-white font-[500] hover:opacity-90 transition-all duration-200'
+                                                onClick={() => setModal11Open(false)}
+                                            >
+                                                Continue
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {blurModalCode && (
+                            <Showcode
+                                code='
+import React, {useState} from "react";
+
+// react icons
+import {RxCross1} from "react-icons/rx";
+
+const Modal = () => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    return (
+        <div
+            className={`${
+                isModalOpen
+                    ? " scale-[1] opacity-100"
+                    : " scale-[0] opacity-0"
+            } w-full h-screen fixed top-0 left-0 z-[200000000] backdrop-blur-md dark:bg-black/50 bg-white/30 flex items-center justify-center transition-all duration-300`}
+        >
+            <div
+                className={`w-[90%] md:w-[35%] dark:bg-slate-800 bg-white/90 backdrop-blur-xl border dark:border-slate-700 border-gray-200 rounded-lg p-5 shadow-2xl`}
+            >
+                <div className="w-full flex justify-between items-start">
+                    <div>
+                        <h2 className="text-[1.7rem] dark:text-[#abc2d3] font-[600] text-[#202020]">
+                            Welcome Back!
+                        </h2>
+                        <p className="text-[1rem] dark:text-[#abc2d3]/80 text-[#525252] mt-1">
+                            Continue your journey with us
+                        </p>
+                    </div>
+
+                    <RxCross1
+                        className="p-2 text-[2.5rem] dark:text-[#abc2d3]/80 dark:hover:bg-slate-900/70 hover:bg-gray-100 rounded-full transition-all duration-300 cursor-pointer"
+                        onClick={() => setIsModalOpen(false)}
+                    />
+                </div>
+
+                <div className="mt-6">
+                    <p className="text-[1rem] dark:text-[#abc2d3]/90 text-gray-700 leading-relaxed">
+                        Experience a modern modal with a beautiful blur effect. 
+                        This creates an elegant overlay while maintaining context 
+                        of the content behind it.
+                    </p>
+                </div>
+
+                <div className="flex items-center gap-2 md:gap-3 w-full justify-end mt-8">
+                    <button
+                        className="px-5 py-2.5 dark:hover:bg-slate-900/50 hover:bg-gray-100 border dark:border-slate-700 dark:text-[#abc2d3] border-gray-300 rounded-lg text-[#585858] font-[500] transition-all duration-200"
+                        onClick={() => setIsModalOpen(false)}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className="px-5 py-2.5 bg-[#3B9DF8] rounded-lg text-white font-[500] hover:opacity-90 transition-all duration-200"
+                        onClick={() => setIsModalOpen(false)}
+                    >
+                        Continue
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default Modal;
+              '
                             />
                         )}
                     </ComponentWrapper>

--- a/src/Components/Overview/SidebarContent/Content/Navigation/ProgressBar.jsx
+++ b/src/Components/Overview/SidebarContent/Content/Navigation/ProgressBar.jsx
@@ -42,6 +42,10 @@ const ProgressBar = () => {
     const [circlePreview, setCirclePreview] = useState(true);
     const [circleCode, setCircleCode] = useState(false);
 
+    // striped animated progress bar
+    const [stripedPreview, setStripedPreview] = useState(true);
+    const [stripedCode, setStripedCode] = useState(false);
+
     const [progress, setProgress] = useState(0);
     const [isLoading, setIsLoading] = useState(false);
 
@@ -263,7 +267,7 @@ export default ProgressBar;
                                         ></div>
                                     </div>
 
-                                    <p>
+                                    <p className='dark:text-gray-400'>
                                         Loading: <b>{progress}%</b>
                                     </p>
                                 </div>
@@ -385,7 +389,7 @@ export default ProgressBar;
                                         />
                                     </svg>
 
-                                    <p className='absolute top-[35%] left-[30%] translate-x-1/2 transform translate-y-1/2'>
+                                    <p className='absolute top-[35%] left-[30%] translate-x-1/2 transform translate-y-1/2 dark:text-gray-400'>
                                         {progress}%
                                     </p>
                                 </div>
@@ -474,6 +478,111 @@ const ProgressBar = () => {
             <button onClick={handleStartLoading}
                     className={`bg-blue-500 rounded-md text-[0.8rem] px-2 py-1 mx-auto`}>Start Loading
             </button>
+        </>
+    );
+};
+
+export default ProgressBar;
+                                '
+                            />
+                        )}
+                    </ComponentWrapper>
+
+                    <div className='mt-8'>
+                        <ContentHeader
+                            text={'striped animated progress bar'}
+                            id={'striped_animated_progress_bar'}
+                        />
+                    </div>
+
+                    <ComponentDescription text='A progress bar with animated diagonal stripes that move across the bar,
+            providing a dynamic visual indication of ongoing progress.'/>
+
+                    <ToggleTab setPreview={setStripedPreview} code={stripedCode} preview={stripedPreview}
+                               setCode={setStripedCode}/>
+
+                    <ComponentWrapper>
+                        {stripedPreview && (
+                            <div className='p-8 mb-4 flex flex-col pt-12 flex-wrap items-center gap-5 justify-center'>
+                                <div className='relative dark:bg-slate-700 bg-gray-200 w-[80%] h-[15px] rounded-full overflow-hidden'>
+                                    <div
+                                        className='absolute top-0 left-0 bg-primary h-full rounded-full transition-all duration-300'
+                                        style={{
+                                            width: `${progress}%`,
+                                            backgroundImage: 'linear-gradient(45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%, transparent)',
+                                            backgroundSize: '30px 30px',
+                                            animation: progress > 0 ? 'progress-stripes 1s linear infinite' : 'none'
+                                        }}
+                                    ></div>
+                                </div>
+
+                                <button
+                                    onClick={handleStartLoading}
+                                    className={`${utils.buttonSecondary} text-[0.8rem] !px-2 !py-1`}
+                                >
+                                    Start Loading
+                                </button>
+
+                                <style>{`
+                                    @keyframes progress-stripes {
+                                        0% {
+                                            background-position: 0 0;
+                                        }
+                                        100% {
+                                            background-position: 30px 0;
+                                        }
+                                    }
+                                `}</style>
+                            </div>
+                        )}
+
+                        {stripedCode && (
+                            <Showcode
+                                code='
+import React, {useState} from "react";
+
+const ProgressBar = () => {
+    const [progress, setProgress] = useState(0);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleStartLoading = () => {
+        if (isLoading) {
+            setProgress(0);
+            setIsLoading(false);
+        }
+
+        setProgress(0);
+        setIsLoading(true);
+    };
+
+    return (
+        <>
+            <div className="relative bg-gray-200 dark:bg-slate-700 w-[80%] h-[15px] rounded-full overflow-hidden">
+                <div 
+                    className="absolute top-0 left-0 bg-primary h-full rounded-full transition-all duration-300"
+                    style={{
+                        width: `${progress}%`,
+                        backgroundImage: "linear-gradient(45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%, transparent)",
+                        backgroundSize: "30px 30px",
+                        animation: progress > 0 ? "progress-stripes 1s linear infinite" : "none"
+                    }}
+                ></div>
+            </div>
+
+            <button onClick={handleStartLoading}
+                    className={`text-[0.8rem] px-2 py-1 bg-blue-500 rounded-md`}>Start Loading
+            </button>
+
+            <style>{`
+                @keyframes progress-stripes {
+                    0% {
+                        background-position: 0 0;
+                    }
+                    100% {
+                        background-position: 30px 0;
+                    }
+                }
+            `}</style>
         </>
     );
 };


### PR DESCRIPTION
Issue:
<img width="1152" height="900" alt="Screenshot_1946" src="https://github.com/user-attachments/assets/0f8850ad-4df8-4d66-ab57-174d1bccf78e" />

Features:
- Add new focused modal variant with frosted glass blur effect
- Added Striped loader progress bar 
<img width="1266" height="939" alt="Screenshot_1947" src="https://github.com/user-attachments/assets/1b421c36-0edd-4326-8eb6-e941c1b81999" />
<img width="1742" height="820" alt="Screenshot_1949" src="https://github.com/user-attachments/assets/79488605-743b-4b72-8dda-e3620b19a465" />
<img width="847" height="419" alt="Screenshot_1950" src="https://github.com/user-attachments/assets/681c6fd1-4163-413e-8559-e361bd58dd35" />

Fixes:
- Dark mode loader progress bar now visible
- Consistent hover styles matching theme colors

<img width="841" height="454" alt="Screenshot_1948" src="https://github.com/user-attachments/assets/7a97b2f6-4835-4c8e-91a0-e947370c8c03" />

